### PR TITLE
Ensure ambient audio asset is generated before running scripts

### DIFF
--- a/cosmoscope/README.md
+++ b/cosmoscope/README.md
@@ -12,10 +12,11 @@ npm run dev
 The development server starts on [http://localhost:5173](http://localhost:5173).
 
 > **Note**
-> The `postinstall` script materialises the ambient soundtrack by decoding
+> The `generate:audio` helper materialises the ambient soundtrack by decoding
 > `src/assets/audio/ambient-space.mp3.base64` into
-> `src/assets/audio/ambient-space.mp3`. Re-run `node ./scripts/generate-audio.mjs`
-> if you ever remove the generated asset manually.
+> `src/assets/audio/ambient-space.mp3`. It runs automatically after dependency
+> installation and before key npm scripts, but you can re-run it manually with
+> `node ./scripts/generate-audio.mjs` if you ever remove the generated asset.
 
 ### Available scripts
 

--- a/cosmoscope/package.json
+++ b/cosmoscope/package.json
@@ -4,14 +4,21 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "predev": "npm run generate:audio",
     "dev": "vite",
+    "prebuild": "npm run generate:audio",
     "build": "tsc --noEmit && vite build",
+    "prepreview": "npm run generate:audio",
     "preview": "vite preview",
+    "pretest": "npm run generate:audio",
     "test": "vitest run",
+    "pretest:watch": "npm run generate:audio",
     "test:watch": "vitest",
+    "pretest:e2e": "npm run generate:audio",
     "test:e2e": "playwright test",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "format": "prettier --write .",
+    "generate:audio": "node ./scripts/generate-audio.mjs",
     "postinstall": "node ./scripts/generate-audio.mjs"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- run the audio generation helper before dev, build, preview, and test npm scripts so the ambient mp3 is always present
- expose the helper through a reusable npm script and update documentation to describe the automated generation flow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d5964fb6c8832ebc221ba41a9d3995