### PR TITLE
Add resizable panels to Solar System layout

### DIFF
--- a/cosmoscope/src/app.css
+++ b/cosmoscope/src/app.css
@@ -23,3 +23,122 @@ button {
   background: rgba(0, 246, 255, 0.35);
   border-radius: 999px;
 }
+
+.resizable-panels {
+  --panel-primary: 65%;
+  --panel-secondary: 35%;
+  display: flex;
+  gap: clamp(1rem, 2vw, 2rem);
+  position: relative;
+}
+
+.resizable-panels__pane {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 0 0 auto;
+}
+
+.resizable-panels__pane--primary {
+  flex-basis: var(--panel-primary);
+}
+
+.resizable-panels__pane--secondary {
+  flex-basis: var(--panel-secondary);
+}
+
+.resizable-panels__handle {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 2px;
+  margin-inline: clamp(0.25rem, 0.75vw, 0.75rem);
+  cursor: col-resize;
+  touch-action: none;
+  user-select: none;
+  border: none;
+  background: transparent;
+  padding: 0;
+}
+
+.resizable-panels__handle::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  margin-inline: auto;
+  width: 3px;
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(0, 246, 255, 0.55), rgba(255, 91, 255, 0.55));
+  box-shadow: 0 0 0 0 rgba(0, 246, 255, 0.35);
+  opacity: 0.6;
+  transition: opacity 0.2s ease, box-shadow 0.2s ease;
+}
+
+.resizable-panels__handle::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-50%);
+  left: 50%;
+  width: 1.75rem;
+}
+
+.resizable-panels__handle:hover::before,
+.resizable-panels__handle:focus-visible::before,
+.resizable-panels__handle--active::before,
+[data-resizing="true"] .resizable-panels__handle::before {
+  opacity: 1;
+  box-shadow: 0 0 18px rgba(0, 246, 255, 0.45);
+}
+
+.resizable-panels__grip {
+  position: relative;
+  width: 100%;
+  height: 60%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.resizable-panels__grip::before,
+.resizable-panels__grip::after {
+  content: "";
+  position: absolute;
+  width: 8px;
+  height: 2px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.6);
+  opacity: 0.6;
+}
+
+.resizable-panels__grip::before {
+  transform: translateY(-6px);
+}
+
+.resizable-panels__grip::after {
+  transform: translateY(6px);
+}
+
+@media (max-width: 1024px) {
+  .resizable-panels {
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  .resizable-panels__pane {
+    flex: 1 1 auto;
+    width: 100%;
+  }
+
+  .resizable-panels__pane--primary,
+  .resizable-panels__pane--secondary {
+    flex-basis: auto;
+  }
+
+  .resizable-panels__handle {
+    display: none;
+  }
+}

--- a/cosmoscope/src/components/NeonPopup.tsx
+++ b/cosmoscope/src/components/NeonPopup.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import type { MissionRef } from "@/adapters/DataAdapter";
+import { cn } from "@/utils/cn";
 
 interface NeonPopupProps {
   title: string;
@@ -12,6 +13,9 @@ interface NeonPopupProps {
   onClose?: () => void;
   actionLabel?: string;
   children?: ReactNode;
+  className?: string;
+  contentClassName?: string;
+  footerClassName?: string;
 }
 
 export const NeonPopup = ({
@@ -23,14 +27,17 @@ export const NeonPopup = ({
   onClose,
   actionLabel = "Travel to the planet",
   children,
+  className,
+  contentClassName,
+  footerClassName,
 }: NeonPopupProps) => {
   return (
-    <Card className="neon-popup w-full max-w-md">
+    <Card className={cn("neon-popup flex w-full max-w-md flex-col overflow-hidden", className)}>
       <CardHeader>
         <CardTitle>{title}</CardTitle>
         {subtitle ? <CardDescription>{subtitle}</CardDescription> : null}
       </CardHeader>
-      <CardContent>
+      <CardContent className={cn("flex-1 overflow-y-auto pr-1", contentClassName)}>
         <p className="font-light text-white/80">{summary}</p>
         {missions.length > 0 ? (
           <div className="mt-4">
@@ -50,7 +57,7 @@ export const NeonPopup = ({
         ) : null}
         {children}
       </CardContent>
-      <CardFooter>
+      <CardFooter className={cn("mt-6 flex flex-wrap items-center gap-3", footerClassName)}>
         {onTravel ? (
           <Button onClick={onTravel}>{actionLabel}</Button>
         ) : null}

--- a/cosmoscope/src/components/SolarSystemScene.tsx
+++ b/cosmoscope/src/components/SolarSystemScene.tsx
@@ -236,6 +236,30 @@ const PlanetSurfaceMaterial = ({
     );
   }
 
+  return (
+    <PlanetSurfaceMaterialWithTexture
+      color={color}
+      opacity={opacity}
+      textureUrl={textureUrl}
+      emissiveColor={emissiveColor}
+      emissiveIntensity={emissiveIntensity}
+    />
+  );
+};
+
+const PlanetSurfaceMaterialWithTexture = ({
+  color,
+  opacity,
+  textureUrl,
+  emissiveColor,
+  emissiveIntensity,
+}: {
+  color: Color;
+  opacity: number;
+  textureUrl: string;
+  emissiveColor?: string;
+  emissiveIntensity?: number;
+}) => {
   const texture = useTexture(textureUrl);
   texture.colorSpace = SRGBColorSpace;
 
@@ -258,18 +282,47 @@ const RingMesh = ({
   textureUrl,
   tilt,
 }: NonNullable<PlanetMeshProps["ring"]>) => {
-  const texture = textureUrl ? useTexture(textureUrl) : null;
-
-  if (texture) {
-    texture.colorSpace = SRGBColorSpace;
-    texture.wrapS = texture.wrapT = RepeatWrapping;
+  if (!textureUrl) {
+    return (
+      <mesh rotation={[-Math.PI / 2 + (tilt ?? 0), 0, 0]}>
+        <ringGeometry args={[innerRadius, outerRadius, 128]} />
+        <meshStandardMaterial
+          color="#c7bb90"
+          side={DoubleSide}
+          transparent
+          opacity={opacity}
+        />
+      </mesh>
+    );
   }
+
+  return (
+    <RingMeshWithTexture
+      innerRadius={innerRadius}
+      outerRadius={outerRadius}
+      opacity={opacity}
+      textureUrl={textureUrl}
+      tilt={tilt}
+    />
+  );
+};
+
+const RingMeshWithTexture = ({
+  innerRadius,
+  outerRadius,
+  opacity,
+  textureUrl,
+  tilt,
+}: NonNullable<PlanetMeshProps["ring"]>) => {
+  const texture = useTexture(textureUrl);
+  texture.colorSpace = SRGBColorSpace;
+  texture.wrapS = texture.wrapT = RepeatWrapping;
 
   return (
     <mesh rotation={[-Math.PI / 2 + (tilt ?? 0), 0, 0]}>
       <ringGeometry args={[innerRadius, outerRadius, 128]} />
       <meshStandardMaterial
-        map={texture ?? undefined}
+        map={texture}
         color="#c7bb90"
         side={DoubleSide}
         transparent

--- a/cosmoscope/src/components/layout/ResizablePanels.tsx
+++ b/cosmoscope/src/components/layout/ResizablePanels.tsx
@@ -1,0 +1,288 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { ReactNode, CSSProperties } from "react";
+
+import { cn } from "@/utils/cn";
+
+const clamp = (value: number, min: number, max: number) => {
+  if (Number.isNaN(value)) return min;
+  return Math.min(Math.max(value, min), max);
+};
+
+interface Constraints {
+  min: number;
+  max: number;
+}
+
+export interface ResizablePanelsProps {
+  primary: ReactNode;
+  secondary: ReactNode;
+  /**
+   * Initial width ratio for the primary pane (0 - 1).
+   */
+  initialRatio?: number;
+  /** Minimum width for the primary pane in pixels. */
+  minPrimaryWidth?: number;
+  /** Minimum width for the secondary pane in pixels. */
+  minSecondaryWidth?: number;
+  /** Maximum width for the primary pane in pixels. */
+  maxPrimaryWidth?: number;
+  /** Maximum width for the secondary pane in pixels. */
+  maxSecondaryWidth?: number;
+  /**
+   * Optional localStorage key used to persist the split ratio.
+   * When omitted, the ratio will not be persisted.
+   */
+  storageKey?: string;
+  /** Additional class names for the container. */
+  className?: string;
+  /** Accessible label for the resize handle. */
+  handleLabel?: string;
+}
+
+const DEFAULT_RATIO = 0.65;
+const KEYBOARD_STEP = 16;
+
+export function ResizablePanels({
+  primary,
+  secondary,
+  initialRatio = DEFAULT_RATIO,
+  minPrimaryWidth = 280,
+  minSecondaryWidth = 280,
+  maxPrimaryWidth,
+  maxSecondaryWidth,
+  storageKey = "cosmoscope:resizable-panels",
+  className,
+  handleLabel = "Resize panels",
+}: ResizablePanelsProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+  const readInitialRatio = useCallback(() => {
+    if (typeof window === "undefined") {
+      return clamp(initialRatio, 0, 1);
+    }
+
+    try {
+      const stored = storageKey ? window.localStorage.getItem(storageKey) : null;
+      if (!stored) {
+        return clamp(initialRatio, 0, 1);
+      }
+      const parsed = Number.parseFloat(stored);
+      if (!Number.isFinite(parsed)) {
+        return clamp(initialRatio, 0, 1);
+      }
+      return clamp(parsed, 0, 1);
+    } catch (error) {
+      console.warn("Failed to read persisted panel ratio", error);
+      return clamp(initialRatio, 0, 1);
+    }
+  }, [initialRatio, storageKey]);
+
+  const [ratio, setRatio] = useState<number>(() => readInitialRatio());
+  const ratioRef = useRef(ratio);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const calculateConstraints = useCallback(
+    (width?: number): Constraints => {
+      const container = containerRef.current;
+      const containerSize = width ?? container?.getBoundingClientRect().width ?? 0;
+
+      if (!containerSize) {
+        return { min: 0, max: 1 };
+      }
+
+      let minRatio = (minPrimaryWidth ?? 0) / containerSize;
+      let maxRatio = 1 - (minSecondaryWidth ?? 0) / containerSize;
+
+      if (typeof maxPrimaryWidth === "number") {
+        maxRatio = Math.min(maxRatio, maxPrimaryWidth / containerSize);
+      }
+      if (typeof maxSecondaryWidth === "number") {
+        const minFromSecondary = 1 - maxSecondaryWidth / containerSize;
+        minRatio = Math.max(minRatio, minFromSecondary);
+      }
+
+      if (minRatio > maxRatio) {
+        const midpoint = clamp((minRatio + maxRatio) / 2 || 0.5, 0, 1);
+        minRatio = midpoint;
+        maxRatio = midpoint;
+      }
+
+      return {
+        min: clamp(minRatio, 0, 1),
+        max: clamp(maxRatio, 0, 1),
+      };
+    },
+    [maxPrimaryWidth, maxSecondaryWidth, minPrimaryWidth, minSecondaryWidth],
+  );
+
+  const applyConstraints = useCallback(
+    (nextRatio: number, width?: number) => {
+      const { min, max } = calculateConstraints(width);
+      return clamp(nextRatio, min, max);
+    },
+    [calculateConstraints],
+  );
+
+  useEffect(() => {
+    ratioRef.current = ratio;
+  }, [ratio]);
+
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!node || typeof ResizeObserver === "undefined") {
+      return;
+    }
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      const width = entry.contentRect.width;
+      setContainerWidth(width);
+      setRatio((prev) => applyConstraints(prev, width));
+    });
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [applyConstraints]);
+
+  useEffect(() => {
+    if (!storageKey || typeof window === "undefined") {
+      return;
+    }
+    try {
+      window.localStorage.setItem(storageKey, ratioRef.current.toString());
+    } catch (error) {
+      console.warn("Failed to persist panel ratio", error);
+    }
+  }, [ratio, storageKey]);
+
+  useEffect(() => {
+    if (!containerWidth) {
+      return;
+    }
+    setRatio((prev) => applyConstraints(prev, containerWidth));
+  }, [applyConstraints, containerWidth]);
+
+  const updateFromPointer = useCallback(
+    (clientX: number) => {
+      const container = containerRef.current;
+      if (!container) return;
+      const rect = container.getBoundingClientRect();
+      if (rect.width <= 0) return;
+      const offset = clamp(clientX - rect.left, 0, rect.width);
+      const next = offset / rect.width;
+      setRatio((prev) => {
+        const constrained = applyConstraints(next, rect.width);
+        return Math.abs(constrained - prev) > 0.0001 ? constrained : prev;
+      });
+    },
+    [applyConstraints],
+  );
+
+  const handlePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (event.button !== 0) return;
+      event.preventDefault();
+      const pointerId = event.pointerId;
+      setIsDragging(true);
+      const target = event.currentTarget;
+      target.setPointerCapture(pointerId);
+      updateFromPointer(event.clientX);
+
+      const handleMove = (moveEvent: PointerEvent) => {
+        updateFromPointer(moveEvent.clientX);
+      };
+
+      const handleUp = () => {
+        setIsDragging(false);
+        target.releasePointerCapture(pointerId);
+        window.removeEventListener("pointermove", handleMove);
+        window.removeEventListener("pointerup", handleUp);
+      };
+
+      window.addEventListener("pointermove", handleMove);
+      window.addEventListener("pointerup", handleUp, { once: true });
+    },
+    [updateFromPointer],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      const container = containerRef.current;
+      if (!container) return;
+      const rect = container.getBoundingClientRect();
+      if (rect.width <= 0) return;
+
+      const constraints = calculateConstraints(rect.width);
+
+      if (event.key === "Home") {
+        event.preventDefault();
+        setRatio(constraints.min);
+        return;
+      }
+
+      if (event.key === "End") {
+        event.preventDefault();
+        setRatio(constraints.max);
+        return;
+      }
+
+      const step = event.shiftKey ? KEYBOARD_STEP * 2 : KEYBOARD_STEP;
+      let delta = 0;
+
+      if (event.key === "ArrowLeft") {
+        delta = -step;
+      } else if (event.key === "ArrowRight") {
+        delta = step;
+      } else {
+        return;
+      }
+
+      event.preventDefault();
+      const deltaRatio = delta / rect.width;
+      setRatio((prev) => applyConstraints(prev + deltaRatio, rect.width));
+    },
+    [applyConstraints, calculateConstraints],
+  );
+
+  const constraints = useMemo(() => calculateConstraints(containerWidth), [calculateConstraints, containerWidth]);
+
+  const style = useMemo(() => {
+    const cssVars: CSSProperties = {
+      ["--panel-primary" as string]: `${(ratio * 100).toFixed(2)}%`,
+      ["--panel-secondary" as string]: `${((1 - ratio) * 100).toFixed(2)}%`,
+    };
+    return cssVars;
+  }, [ratio]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn("resizable-panels", className)}
+      data-resizing={isDragging ? "true" : "false"}
+      data-orientation="horizontal"
+      style={style}
+    >
+      <div className="resizable-panels__pane resizable-panels__pane--primary">{primary}</div>
+      {/* eslint-disable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/no-noninteractive-tabindex */}
+      <div
+        role="separator"
+        tabIndex={0}
+        aria-orientation="vertical"
+        aria-label={handleLabel}
+        aria-valuemin={Math.round(constraints.min * 100)}
+        aria-valuemax={Math.round(constraints.max * 100)}
+        aria-valuenow={Math.round(clamp(ratio, 0, 1) * 100)}
+        className={cn("resizable-panels__handle", isDragging && "resizable-panels__handle--active")}
+        onPointerDown={handlePointerDown}
+        onKeyDown={handleKeyDown}
+      >
+        <span aria-hidden className="resizable-panels__grip" />
+      </div>
+      {/* eslint-enable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/no-noninteractive-tabindex */}
+      <div className="resizable-panels__pane resizable-panels__pane--secondary">{secondary}</div>
+    </div>
+  );
+}
+
+export default ResizablePanels;

--- a/cosmoscope/src/routes/SolarSystem.tsx
+++ b/cosmoscope/src/routes/SolarSystem.tsx
@@ -10,6 +10,7 @@ import { dataAdapter } from "@/adapters/NasaAdapter";
 import type { PlanetDetail, PlanetSummary } from "@/adapters/DataAdapter";
 import { usePlanetStore, type CameraMode } from "@/state/usePlanetStore";
 import { createWarpTimeline } from "@/lib/cameraTransitions";
+import { ResizablePanels } from "@/components/layout/ResizablePanels";
 
 const INTERACTABLE_PLANETS = new Set(["earth", "moon", "mars"]);
 
@@ -99,59 +100,73 @@ export default function SolarSystem() {
           <ToggleGroupItem value="top-down">Top</ToggleGroupItem>
         </ToggleGroup>
       </header>
-      <main className="grid flex-1 grid-cols-1 gap-8 px-8 pb-12 lg:grid-cols-[2fr_1fr]">
-        <section className="relative min-h-[60vh] overflow-hidden rounded-3xl border border-white/10 shadow-[0_0_40px_rgba(0,246,255,0.2)]">
-          <SolarSystemScene
-            cameraMode={cameraMode}
-            selectedPlanetId={currentPlanet ?? undefined}
-            onPlanetClick={handlePlanetFocus}
-            onPlanetDoubleClick={handleTravel}
-          />
-          {isWarping ? (
-            <div className="pointer-events-none absolute inset-0 animate-pulse bg-gradient-to-br from-neon-blue/20 via-neon-pink/15 to-transparent" />
-          ) : null}
-        </section>
-        <aside className="flex flex-col gap-6">
-          <div className="rounded-3xl border border-white/10 bg-space-mid/70 p-6 backdrop-blur-2xl">
-            <h2 className="text-sm uppercase tracking-[0.4em] text-neon-blue">Mission Log</h2>
-            <ul className="mt-4 space-y-3 text-sm text-white/70">
-              {summaries.map((summary) => (
-                <li key={summary.id} className="flex items-center justify-between">
-                  <span>{summary.name}</span>
-                  <Button
-                    variant={summary.id === currentPlanet ? "default" : "outline"}
-                    size="sm"
-                    onClick={() => handlePlanetFocus(summary.id)}
-                  >
-                    {summary.id === currentPlanet ? "Selected" : "Focus"}
-                  </Button>
-                </li>
-              ))}
-            </ul>
-          </div>
-          {selectedSummary && detail ? (
-            <NeonPopup
-              title={selectedSummary.name}
-              subtitle={`${detail.age} · Gravity ${detail.gravity}`}
-              summary={detail.description}
-              missions={missionRefs}
-              onTravel={() => handleTravel(selectedSummary.id)}
-              onClose={() => setCurrentPlanet(null)}
-            >
-              {infoHighlight.length > 0 ? (
-                <ul className="mt-4 list-disc space-y-1 pl-6 text-xs text-white/70">
-                  {infoHighlight.map((fact) => (
-                    <li key={fact}>{fact}</li>
+      <main className="flex-1 px-8 pb-12">
+        <ResizablePanels
+          className="h-full"
+          initialRatio={0.65}
+          minPrimaryWidth={360}
+          minSecondaryWidth={320}
+          maxSecondaryWidth={640}
+          storageKey="cosmoscope:solar-system-panels"
+          handleLabel="Resize mission console"
+          primary={
+            <section className="relative flex h-full min-h-[60vh] overflow-hidden rounded-3xl border border-white/10 shadow-[0_0_40px_rgba(0,246,255,0.2)]">
+              <SolarSystemScene
+                cameraMode={cameraMode}
+                selectedPlanetId={currentPlanet ?? undefined}
+                onPlanetClick={handlePlanetFocus}
+                onPlanetDoubleClick={handleTravel}
+              />
+              {isWarping ? (
+                <div className="pointer-events-none absolute inset-0 animate-pulse bg-gradient-to-br from-neon-blue/20 via-neon-pink/15 to-transparent" />
+              ) : null}
+            </section>
+          }
+          secondary={
+            <aside className="flex h-full min-h-[320px] flex-1 flex-col gap-6 overflow-hidden">
+              <div className="rounded-3xl border border-white/10 bg-space-mid/70 p-6 backdrop-blur-2xl lg:max-h-[45vh] lg:overflow-y-auto">
+                <h2 className="text-sm uppercase tracking-[0.4em] text-neon-blue">Mission Log</h2>
+                <ul className="mt-4 space-y-3 text-sm text-white/70">
+                  {summaries.map((summary) => (
+                    <li key={summary.id} className="flex items-center justify-between gap-3">
+                      <span className="truncate">{summary.name}</span>
+                      <Button
+                        variant={summary.id === currentPlanet ? "default" : "outline"}
+                        size="sm"
+                        onClick={() => handlePlanetFocus(summary.id)}
+                      >
+                        {summary.id === currentPlanet ? "Selected" : "Focus"}
+                      </Button>
+                    </li>
                   ))}
                 </ul>
-              ) : null}
-              <div className="mt-4 flex flex-wrap gap-3 text-xs uppercase tracking-[0.3em] text-neon-blue">
-                <span>Orbit {detail.orbitalPeriodDays} days</span>
-                <span>Rotation {detail.rotationHours}h</span>
               </div>
-            </NeonPopup>
-          ) : null}
-        </aside>
+              {selectedSummary && detail ? (
+                <NeonPopup
+                  className="max-w-none overflow-hidden lg:flex-1"
+                  title={selectedSummary.name}
+                  subtitle={`${detail.age} · Gravity ${detail.gravity}`}
+                  summary={detail.description}
+                  missions={missionRefs}
+                  onTravel={() => handleTravel(selectedSummary.id)}
+                  onClose={() => setCurrentPlanet(null)}
+                >
+                  {infoHighlight.length > 0 ? (
+                    <ul className="mt-4 list-disc space-y-1 pl-6 text-xs text-white/70">
+                      {infoHighlight.map((fact) => (
+                        <li key={fact}>{fact}</li>
+                      ))}
+                    </ul>
+                  ) : null}
+                  <div className="mt-4 flex flex-wrap gap-3 text-xs uppercase tracking-[0.3em] text-neon-blue">
+                    <span>Orbit {detail.orbitalPeriodDays} days</span>
+                    <span>Rotation {detail.rotationHours}h</span>
+                  </div>
+                </NeonPopup>
+              ) : null}
+            </aside>
+          }
+        />
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary
- add a reusable `ResizablePanels` layout component with pointer and keyboard resizing plus localStorage persistence
- style the resizer handle with hover/active states and responsive stacking fallbacks
- integrate the Solar System route with the new panels and update related components for fluid sizing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d5b898b37c832eacf2505f7bed9045